### PR TITLE
Hotfix inbox null and timestamp

### DIFF
--- a/src/backend/src/main/java/com/example/backend/api/controllers/message/MessageController.java
+++ b/src/backend/src/main/java/com/example/backend/api/controllers/message/MessageController.java
@@ -262,12 +262,17 @@ public class MessageController {
         TextMessageDbEntity recentTextMessage = messageDbService.getMostRecentMessageById(id);
         SentImageDbEntity recentImageMessage = sentImageDbService.getMostRecentMessageById(id);
 
+        if((recentTextMessage == null && recentImageMessage == null)
+                || (recentTextMessage.getMessageId() == 0 && recentImageMessage.getImageId() == 0)) {
+            return new ArrayList<>();
+        }
+
         if(recentTextMessage
                 .getDate()
                 .concat(" " + recentTextMessage.getHour())
                 .compareTo(recentImageMessage
                                             .getDate()
-                                            .concat(" " + recentImageMessage.getHour())) < 0) {
+                                            .concat(" " + recentImageMessage.getHour())) > 0) {
             recentTextMessage.setContentType(1);
 
             return List.of(recentTextMessage);

--- a/src/backend/src/main/java/com/example/backend/services/database/MessageDbService.java
+++ b/src/backend/src/main/java/com/example/backend/services/database/MessageDbService.java
@@ -68,7 +68,9 @@ public class MessageDbService {
     }
 
     public TextMessageDbEntity getMostRecentMessageById(Long id) {
-        return repo.getMostRecentMessageById(id);
+        TextMessageDbEntity message = repo.getMostRecentMessageById(id);
+
+        return message != null ? message : new TextMessageDbEntity(id, "", "", "", "", "");
     }
 
     public TextMessageDbEntity getMostRecentMessageByRecipients(String user1, String user2) {

--- a/src/backend/src/main/java/com/example/backend/services/database/SentImageDbService.java
+++ b/src/backend/src/main/java/com/example/backend/services/database/SentImageDbService.java
@@ -59,6 +59,8 @@ public class SentImageDbService {
     }
 
     public SentImageDbEntity getMostRecentMessageById(Long conversationId) {
-        return repo.getMostRecentMessageById(conversationId);
+        SentImageDbEntity image = repo.getMostRecentMessageById(conversationId);
+
+        return image != null ? image : new SentImageDbEntity(conversationId, "", "", "", "", "");
     }
 }


### PR DESCRIPTION
## Hotfix inbox null and timestamp
Solved an bug related to accessing the `/api/conversation/{conversation_id}/message` endpoint with the `inbox` type option selected

## Details of the issues
- **Internal server error while accessing `/api/conversation/{conversation_id}/message?type=inbox`**

When trying to access the `/api/conversation/{conversation_id}/message` endpoint if there was no text message or no image saved into the database when trying to return the message from the controller it would cause an internal server error caused by a `NullPointerException`[^1]

- **Incorrect message order when accesing `/api/conversation/{conversation_id}/message?type=inbox`**

When trying to access the endpoint the JSON object will not return the most recent message 

## Code changes
*`MessageDbService.java`*
- `getMostRecentMessageById` returns an empty `TextMessageDbEntity` object if the result of the query is null

*`SentImageDbService.java`*
- `getMostRecentImageById` returns an empty `SentImageDbEntity` object if the result of the query is null

*`MessageController.java`*
- in the `getInbox` method if the most recent element provided by the `MessageDbService` and `SentImageDbService` are both null, the method will return an empty array
- in the `getInbox` method the timestamp comparison logic has been modified to send the most recent message

[^1]: [NullPointerException](https://docs.oracle.com/javase/8/docs/api/java/lang/NullPointerException.html)